### PR TITLE
Adding pointer to an alternate template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 Ever wish it was as easy to build a Figma plugin as it is to build a website? Well no look no further! This template will allow you to develop your Figma plugin in your favourite browser while interacting with the Figma app. Use your favourite browser extensions such as React Developer Tools to help debug your issues faster, and take advantage of the built in hot-reloading to preview your changes instantaneously without having to constantly rebuild and relaunch your plugin.
 
+
 ![Screen Recording 2021-05-05 at 03 46 11 PM](https://user-images.githubusercontent.com/7476817/117219079-5c0f6580-adb9-11eb-9cfd-6e803d93e3ca.gif)
 ![Screen Recording 2021-05-05 at 03 45 16 PM](https://user-images.githubusercontent.com/7476817/117219001-32563e80-adb9-11eb-839d-d8cde22e5dd1.gif)
+
+**Note:** there's a newer version of this template with tailwindcss, live-reloading, and messaging by [@rlingineni](https://github.com/rlingineni/figma-plugin-react-template)
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ever wish it was as easy to build a Figma plugin as it is to build a website? We
 ![Screen Recording 2021-05-05 at 03 46 11 PM](https://user-images.githubusercontent.com/7476817/117219079-5c0f6580-adb9-11eb-9cfd-6e803d93e3ca.gif)
 ![Screen Recording 2021-05-05 at 03 45 16 PM](https://user-images.githubusercontent.com/7476817/117219001-32563e80-adb9-11eb-839d-d8cde22e5dd1.gif)
 
-**Note:** there's a newer version of this template with tailwindcss, live-reloading, and messaging by [@rlingineni](https://github.com/rlingineni/figma-plugin-react-template)
+**Note:** there's a [newer version](https://github.com/rlingineni/figma-plugin-react-template) of this template with tailwindcss, live-reloading, and messaging by @rlingineni
 
 ## Quickstart
 


### PR DESCRIPTION
Hi, 

I took your work, which is awesome btw, and added a [few more things to it](https://github.com/rlingineni/figma-plugin-react-template). I noticed that it also was broken (I was hitting the same prob as #1 )

Totally optional, but this PR adds a note to the readme to check out the forked template. Great work, and it sped up my development by a lot. Pretty genius. Thanks!
